### PR TITLE
Write sparse loops matrix to save space

### DIFF
--- a/src/util/Statistics.cpp
+++ b/src/util/Statistics.cpp
@@ -114,7 +114,9 @@ void Statistics::writeResults(const std::string& dir, int inliers)
     {
         for (int j = 0; j < loops.cols; j++)
         {
-            loops_file << loops(i, j) << "\t";
+	    	if(loops(i, j) == 1) {
+	            loops_file << j << "\t";
+	    	}
             // Uncomment these lines if you want to save the full Bayes filter info
 
             //prior_file << prior(i, j) << "\t";


### PR DESCRIPTION
htmap_loops_inliers.txt is a 2D matrix with dimensions = number of input images. If the dimensions are, say a big number 32k, the code ends up producing a very large text file of size ~2.2GB